### PR TITLE
add github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,54 @@
+name: Build
+
+on: [pull_request]
+
+jobs:
+  unit-tests:
+    name: vet and test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-go@v2
+      with:
+        go-version: 1.12
+    - uses: actions/checkout@v2
+      with:
+        path: src/github.com/go-ping/ping
+    - run: |
+        export GOPATH=$GITHUB_WORKSPACE
+        cd $GITHUB_WORKSPACE/src/github.com/go-ping/ping
+        go get ./...
+        go vet ./...
+        go test ./... -cover -race
+        
+  build-ping-cmd:
+    name: build ping command and run
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-go@v2
+      with:
+        go-version: 1.12
+    - uses: actions/checkout@v2
+      with:
+        path: src/github.com/go-ping/ping
+    - run: |
+        export GOPATH=$GITHUB_WORKSPACE
+        cd $GITHUB_WORKSPACE/src/github.com/go-ping/ping
+        go build -race -o ping_linux ./cmd/ping/ping.go
+        sudo ./ping_linux --privileged -c 2 www.google.com
+        sudo ./ping_linux --privileged -c 3 -i 200ms www.google.com
+        sudo ./ping_linux --privileged -c 10 -i 100ms -t 1s www.google.com
+  
+  x-platform-build:
+    name: cross platform build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-go@v2
+      with:
+        go-version: 1.12
+    - uses: actions/checkout@v2
+      with:
+        path: src/github.com/aws/amazon-ecs-agent
+    - run: |
+        export GOPATH=$GITHUB_WORKSPACE
+        cd $GITHUB_WORKSPACE/src/github.com/go-ping/ping
+        GOOS=darwin go build -o ping_darwin ./cmd/ping/ping.go


### PR DESCRIPTION
### Description

In this pull request, a GitHub Actions workflow file named `build.yml` is added to the `.github/workflows` directory. This workflow defines three jobs to automate the building, testing, and running of a Go project. Here are the details of the changes made in this pull request:

- Added a new GitHub Actions workflow file `build.yml` to the `.github/workflows` directory.
- The workflow includes three jobs:
  1. `unit-tests` job: This job sets up the Go environment, checks out the code, runs vetting and testing commands.
  2. `build-ping-cmd` job: This job sets up the Go environment, checks out the code, builds the `ping` command for Linux, and runs the built binary with different parameters against `www.google.com`.
  3. `x-platform-build` job: This job sets up the Go environment, checks out the code, and builds the `ping` command for macOS (darwin) by setting the `GOOS=darwin` environment variable.

These changes aim to automate the build and testing processes for the Go project, as well as demonstrate cross-platform building capabilities.

